### PR TITLE
Add parent for ports to work in example

### DIFF
--- a/packages/storybook/stories/node/custom/custom.factory.ts
+++ b/packages/storybook/stories/node/custom/custom.factory.ts
@@ -5,7 +5,7 @@ import {
   Renderer2,
 } from '@angular/core';
 import { AbstractAngularFactory } from '@rxzu/angular';
-import { DefaultNodeModel } from '@rxzu/core';
+import { DefaultNodeModel, DiagramModel } from '@rxzu/core';
 import { CustomNodeComponent } from './custom.component';
 
 export class CustomNodeFactory extends AbstractAngularFactory<
@@ -21,9 +21,11 @@ export class CustomNodeFactory extends AbstractAngularFactory<
   generateWidget({
     model,
     host,
+    diagramModel,
   }: {
     model: DefaultNodeModel;
     host: ViewContainerRef;
+    diagramModel?: DiagramModel;
   }): ViewContainerRef {
     const componentRef = host.createComponent(this.getRecipe());
 
@@ -58,6 +60,7 @@ export class CustomNodeFactory extends AbstractAngularFactory<
       componentRef.instance[key] = value;
     });
 
+    componentRef.instance.setParent(diagramModel);
     componentRef.instance.ngOnInit();
     const portsHost = componentRef.instance.getPortsHost();
     return portsHost;


### PR DESCRIPTION
When attaching a port, the node needs the getDiagramEngine() of the parent
Without, we get an error like this:
ISSUES: #67
```
ERROR TypeError: Cannot read property 'getDiagramEngine' of null
    at node.model.js:26
    at Array.forEach (<anonymous>)
    at SafeSubscriber._next (node.model.js:24)
    at SafeSubscriber.__tryOrUnsub (Subscriber.js:183)
    at SafeSubscriber.next (Subscriber.js:122)
    at Subscriber._next (Subscriber.js:72)
    at Subscriber.next (Subscriber.js:49)
    at TakeUntilSubscriber._next (Subscriber.js:72)
    at TakeUntilSubscriber.next (Subscriber.js:49)
    at TapSubscriber._next (tap.js:46)
```