### PR TITLE
fix(mouse): zoom limitation

### DIFF
--- a/packages/core/src/lib/managers/mouse.manager.ts
+++ b/packages/core/src/lib/managers/mouse.manager.ts
@@ -15,6 +15,7 @@ import { isNil } from '../utils';
 
 export class MouseManager {
   protected engine: DiagramEngine;
+  protected readonly minValidZoom = 1;
 
   constructor(protected _diagramEngine: DiagramEngine) {
     this.engine = _diagramEngine;
@@ -473,7 +474,7 @@ export class MouseManager {
       scrollDelta /= 60;
     }
 
-    if (currentZoomLevel + scrollDelta > 10) {
+    if (currentZoomLevel + scrollDelta >= this.minValidZoom) {
       const newZoomLvl = currentZoomLevel + scrollDelta;
       this.diagramModel.setZoomLevel(newZoomLvl);
     }


### PR DESCRIPTION
currently, zoom on mousewheel is not working for huge diagrams (e.g. Performance story).
the reason is the minimum zoom we check for before setting it.
Any zoom level equals and above 1 is valid for transform values.