### PR TITLE
feat(diagram): add ability to animate layout changes

### DIFF
--- a/packages/angular-storybook/.storybook/preview.js
+++ b/packages/angular-storybook/.storybook/preview.js
@@ -18,6 +18,7 @@ export const parameters = {
         'Drag And Drop',
         'Dynamic Ports',
         'Performance',
+        'Layout Animation',
         'Actions',
         'Themes',
         'Changelog',

--- a/packages/angular-storybook/stories/animation/animation.component.ts
+++ b/packages/angular-storybook/stories/animation/animation.component.ts
@@ -1,0 +1,82 @@
+import { AfterViewInit, Component, OnInit, ViewChild } from '@angular/core';
+import {
+  DiagramModel,
+  NodeModel,
+  PortModel,
+  RxZuDiagramComponent,
+} from '@rxzu/angular';
+
+@Component({
+  selector: 'app-root',
+  template: `
+    <div class="action-bar">
+      <button (click)="zoomToNodes()">
+        Zoom to selected nodes with default animation
+      </button>
+      <button (click)="zoomToFit()">Zoom to fit with 500ms ease-out</button>
+    </div>
+    <rxzu-diagram class="demo-diagram" [model]="diagramModel"></rxzu-diagram>
+  `,
+  styleUrls: ['../demo-diagram.component.scss'],
+})
+export class AnimationStoryComponent implements OnInit, AfterViewInit {
+  diagramModel: DiagramModel;
+  @ViewChild(RxZuDiagramComponent, { static: true })
+  diagram?: RxZuDiagramComponent;
+
+  constructor() {
+    this.diagramModel = new DiagramModel();
+  }
+
+  ngOnInit() {
+    const node1 = new NodeModel();
+    node1.setCoords({ x: 500, y: 300 });
+    const outport1 = new PortModel();
+    node1.addPort(outport1);
+
+    const node2 = new NodeModel();
+    node2.setCoords({ x: 100, y: 100 });
+    const inport = new PortModel();
+    node2.addPort(inport);
+
+    for (let index = 0; index < 2; index++) {
+      const nodeLoop = new NodeModel();
+      nodeLoop.setCoords({
+        x: 1000 * (Math.random() * 10),
+        y: 300 + index * (Math.random() * 10) * 300,
+      });
+      const inportLoop = new PortModel();
+      node2.addPort(inport);
+      nodeLoop.addPort(inportLoop);
+
+      this.diagramModel.addNode(nodeLoop);
+
+      const linkLoop = outport1.link(inportLoop);
+      if (linkLoop) {
+        this.diagramModel.addLink(linkLoop);
+      }
+    }
+
+    this.diagramModel.addAll(node1, node2);
+  }
+
+  ngAfterViewInit() {
+    this.zoomToNodes();
+  }
+
+  zoomToNodes() {
+    this.diagramModel.animate(() => {
+      const selectedNodes = this.diagramModel.getSelectedItems(
+        'node'
+      ) as NodeModel[];
+      this.diagram?.zoomToNodes(selectedNodes);
+    });
+  }
+
+  zoomToFit() {
+    this.diagramModel.animate(() => this.diagram?.zoomToFit(), {
+      timing: 500,
+      easing: 'ease-out',
+    });
+  }
+}

--- a/packages/angular-storybook/stories/animation/animation.stories.ts
+++ b/packages/angular-storybook/stories/animation/animation.stories.ts
@@ -1,0 +1,23 @@
+import { Meta, moduleMetadata, Story } from '@storybook/angular';
+import { CommonModule } from '@angular/common';
+import { RxZuDefaultsModule, DagrePlugin } from '@rxzu/angular';
+import { AnimationStoryComponent } from './animation.component';
+
+export default {
+  title: 'Layout Animation',
+  parameters: { docs: { iframeHeight: '400px' } },
+  decorators: [
+    moduleMetadata({
+      declarations: [AnimationStoryComponent],
+      providers: [DagrePlugin],
+      imports: [CommonModule, RxZuDefaultsModule],
+    }),
+  ],
+} as Meta;
+
+const template: Story<AnimationStoryComponent> = (args: any) => ({
+  component: AnimationStoryComponent,
+  props: args,
+});
+
+export const LayoutAnimation = template.bind({});

--- a/packages/angular/src/lib/diagram/diagram.component.html
+++ b/packages/angular/src/lib/diagram/diagram.component.html
@@ -1,30 +1,20 @@
-<div
-  class="rxzu-diagram"
-  #canvas
-  (mousedown)="onMouseDown($event)"
-  (wheel)="onMouseWheel($event)"
-  (keyup)="onKeyUp($event)"
-  tabindex="1"
->
-  <!-- Nodes Layer -->
-  <div class="rxzu-nodes-layer">
-    <ng-template #nodesLayer></ng-template>
-  </div>
+<!-- Nodes Layer -->
+<div class="rxzu-nodes-layer">
+  <ng-template #nodesLayer></ng-template>
+</div>
 
-  <!-- Links Layer -->
-  <div class="rxzu-links-layer">
-    <ng-template #linksLayer></ng-template>
-  </div>
+<!-- Links Layer -->
+<div class="rxzu-links-layer">
+  <ng-template #linksLayer></ng-template>
+</div>
 
-  <!-- Selection Box -->
-  <div
-    *ngIf="selectionBox$ | async as selectionBox"
-    class="selector"
-    [ngStyle]="{
+<!-- Selection Box -->
+<div *ngIf="selectionBox$ | async as selectionBox"
+     class="selector"
+     [ngStyle]="{
       top: selectionBox?.dimensions?.top + 'px',
       left: selectionBox?.dimensions?.left + 'px',
       width: selectionBox?.dimensions?.width + 'px',
       height: selectionBox?.dimensions?.height + 'px'
-    }"
-  ></div>
+    }">
 </div>

--- a/packages/angular/src/lib/diagram/diagram.component.scss
+++ b/packages/angular/src/lib/diagram/diagram.component.scss
@@ -42,11 +42,4 @@
     left: 0;
     right: 0;
   }
-
-  .rxzu-links-layer,
-  .rxzu-nodes-layer {
-    &.rxzu-animate {
-      transition: transform 0.2s ease-in-out;
-    }
-  }
 }

--- a/packages/angular/src/lib/diagram/diagram.component.scss
+++ b/packages/angular/src/lib/diagram/diagram.component.scss
@@ -46,7 +46,7 @@
   .rxzu-links-layer,
   .rxzu-nodes-layer {
     &.rxzu-animate {
-      transition: transform 0.5s ease-in-out;
+      transition: transform 0.2s ease-in-out;
     }
   }
 }

--- a/packages/angular/src/lib/diagram/diagram.component.scss
+++ b/packages/angular/src/lib/diagram/diagram.component.scss
@@ -1,4 +1,4 @@
-.rxzu-diagram {
+:host {
   position: relative;
   flex-grow: 1;
   display: flex;
@@ -41,5 +41,12 @@
     bottom: 0;
     left: 0;
     right: 0;
+  }
+
+  .rxzu-links-layer,
+  .rxzu-nodes-layer {
+    &.rxzu-animate {
+      transition: transform 0.5s ease-in-out;
+    }
   }
 }

--- a/packages/core/src/lib/interfaces/animation.interface.ts
+++ b/packages/core/src/lib/interfaces/animation.interface.ts
@@ -1,0 +1,11 @@
+export interface AnimationConfig {
+  /**
+   * Timing in ms
+   */
+  timing: number;
+
+  /**
+   * Easing function
+   */
+  easing: 'ease' | 'ease-in' | 'ease-in-out' | 'ease-out' | string;
+}

--- a/packages/core/src/lib/interfaces/index.ts
+++ b/packages/core/src/lib/interfaces/index.ts
@@ -5,3 +5,4 @@ export * from './options.interface';
 export * from './move-selection.interface';
 export * from './select-options.interface';
 export * from './setup.interface';
+export * from './animation.interface';

--- a/packages/core/src/lib/models/diagram.model.ts
+++ b/packages/core/src/lib/models/diagram.model.ts
@@ -2,6 +2,7 @@ import { Observable } from 'rxjs';
 import { BaseEntity } from '../base.entity';
 import { DiagramEngine } from '../engine.core';
 import { SelectOptions, Coords, BaseEntityType } from '../interfaces';
+import { AnimationConfig } from '../interfaces/animation.interface';
 import {
   createEntityState,
   createValueState,
@@ -35,6 +36,7 @@ export class DiagramModel extends BaseEntity {
   protected allowLooseLinks$: ValueState<boolean>;
   protected portMagneticRadius$: ValueState<number>;
   protected keyBindings$: ValueState<KeyBindigsOptions>;
+  protected animation$ = createValueState<AnimationConfig | null>(null);
 
   constructor(
     options: DiagramModelOptions = {},
@@ -341,6 +343,23 @@ export class DiagramModel extends BaseEntity {
 
   selectZoomLevel(): Observable<number> {
     return this.zoom$.value$;
+  }
+
+  selectAnimation(): Observable<AnimationConfig | null> {
+    return this.animation$.select();
+  }
+
+  animate(callback: () => void, config?: AnimationConfig): void {
+    const merged: AnimationConfig = {
+      timing: 200,
+      easing: 'ease-in-out',
+      ...config,
+    };
+    this.animation$.set(merged);
+    callback();
+    setTimeout(() => {
+      this.animation$.set(null);
+    }, merged.timing);
   }
 
   getDiagramEngine(): DiagramEngine | undefined {


### PR DESCRIPTION
This PR introduces an ability to animate layout changes, specifically to positioning (x,y) and zoom.
Usage example:

```ts
// Not passing anything, using default values of { timing: 200, easing: 'ease-in-out' }
zoomToFit() {
    this.diagramModel.animate(() => this.diagram?.zoomToFit());
}

// Passing a custom config
zoomToFit() {
    this.diagramModel.animate(() => this.diagram?.zoomToFit(), {
      timing: 500,
      easing: 'ease-out',
    });
}
```